### PR TITLE
Fixes Maxmind database download breakage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: $(patsubst %.Dockerfile,build-stamp_%,$(wildcard *.Dockerfile))
 
 build-stamp_%: %.Dockerfile
-	docker build -t broplatform/bro:$(*) -f $< . 
+	docker build --build-arg MAXMIND_LICENSE_KEY -t broplatform/bro:$(*) -f $< . 
 	touch $@
 
 push-stamp_%: build-stamp_%

--- a/common/3.0.0.Dockerfile
+++ b/common/3.0.0.Dockerfile
@@ -6,6 +6,7 @@ FROM debian:stretch as builder
 MAINTAINER Justin Azoff <justin.azoff@gmail.com>
 
 ENV WD /scratch
+ARG MAXMIND_LICENSE_KEY
 
 RUN mkdir ${WD}
 WORKDIR /scratch
@@ -24,6 +25,9 @@ RUN ${WD}/common/buildbro zeek ${VER}
 
 FROM debian:stretch as geogetter
 RUN apt-get update && apt-get -y install wget ca-certificates --no-install-recommends
+ADD ./common/getmmdb.sh /usr/local/bin/getmmdb.sh
+RUN /usr/local/bin/getmmdb.sh
+
 
 # Make final image
 FROM debian:stretch
@@ -34,6 +38,7 @@ RUN apt-get update \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /usr/local/zeek-${VER} /usr/local/zeek-${VER}
+COPY --from=geogetter /usr/share/GeoIP/* /usr/share/GeoIP/
 RUN ln -s /usr/local/zeek-${VER} /bro
 RUN ln -s /usr/local/zeek-${VER} /zeek
 ADD ./common/bro_profile.sh /etc/profile.d/zeek.sh

--- a/common/getmmdb.sh
+++ b/common/getmmdb.sh
@@ -1,13 +1,61 @@
 #!/bin/sh -e 
 echo "2018-09-21"
 
-mkdir -p /usr/share/GeoIP/
-wget -N http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.tar.gz
-tar xvzf GeoLite2-City.tar.gz
-rm GeoLite2-City.tar.gz
+get_geoip_db () {
+    # Fetches specified EDITION_ID db from maxmind using
+    # active LICENSE_KEY.
+    # 
+    # This gets the latest version of the db. To get db corresponding to a
+    # particular date, add the following URL paramater:
+    #
+    #   date=YYYYMMDD (e.g. 20200107)
+    #
+    # As described in [2] below, this requires an active user account
+    # and an associated LICENSE_KEY (free).
+    #
+    # References:
+    #
+    # [1] https://dev.maxmind.com/geoip/geoipupdate/#Direct_Downloads
+    # [2] https://blog.maxmind.com/2019/12/18/significant-changes-to-accessing-and-using-geolite2-databases/
 
-wget -N http://geolite.maxmind.com/download/geoip/database/GeoLite2-ASN.tar.gz
-tar xvzf GeoLite2-ASN.tar.gz
-rm GeoLite2-ASN.tar.gz
+    EDITION_ID=$1
+    SUFFIX=$2
+    LICENSE_KEY=$3
 
-mv */*.mmdb /usr/share/GeoIP
+    BASE_URL="https://download.maxmind.com/app/geoip_download"
+    wget "$BASE_URL?edition_id=$EDITION_ID&license_key=$LICENSE_KEY&suffix=$SUFFIX" \
+        -O $EDITION_ID.$SUFFIX
+}
+
+
+main () {
+    # Entry point for the script.
+    #
+    # Relies on build time environment variable: MAXMIND_LICENSE_KEY
+    # to be set.
+    mkdir -p /usr/share/GeoIP/
+
+    MD5_FILE=checksums.md5
+    rm -f $MD5_FILE
+    for DB in GeoLite2-ASN GeoLite2-City
+    do
+        get_geoip_db $DB tar.gz  $MAXMIND_LICENSE_KEY
+        get_geoip_db $DB tar.gz.md5  $MAXMIND_LICENSE_KEY
+
+        # Create MD5 sum file for cehcking
+        cat $DB.tar.gz.md5 >> $MD5_FILE
+        echo " $DB.tar.gz" >> $MD5_FILE
+    done
+
+    md5sum -c $MD5_FILE
+
+    for DB in GeoLite2-ASN GeoLite2-City
+    do
+        tar xvzf $DB.tar.gz
+        rm $DB.tar.gz
+        mv */*.mmdb /usr/share/GeoIP
+    done
+}
+
+
+main


### PR DESCRIPTION
This commit fixes #9.

It removes references to Maxmind database from the 3.0.0.Dockerfile.