### PR TITLE
Fixes Maxmind database download breakage

### DIFF
--- a/3.0.0.Dockerfile
+++ b/3.0.0.Dockerfile
@@ -6,7 +6,6 @@ FROM debian:stretch as builder
 MAINTAINER Justin Azoff <justin.azoff@gmail.com>
 
 ENV WD /scratch
-ARG MAXMIND_LICENSE_KEY
 
 RUN mkdir ${WD}
 WORKDIR /scratch
@@ -24,6 +23,7 @@ RUN ${WD}/common/buildbro zeek ${VER}
 # get geoip data
 
 FROM debian:stretch as geogetter
+ARG MAXMIND_LICENSE_KEY
 RUN apt-get update && apt-get -y install wget ca-certificates --no-install-recommends
 ADD ./common/getmmdb.sh /usr/local/bin/getmmdb.sh
 RUN /usr/local/bin/getmmdb.sh

--- a/3.0.0.Dockerfile
+++ b/3.0.0.Dockerfile
@@ -6,6 +6,7 @@ FROM debian:stretch as builder
 MAINTAINER Justin Azoff <justin.azoff@gmail.com>
 
 ENV WD /scratch
+ARG MAXMIND_LICENSE_KEY
 
 RUN mkdir ${WD}
 WORKDIR /scratch

--- a/3.0.0.Dockerfile
+++ b/3.0.0.Dockerfile
@@ -26,7 +26,10 @@ FROM debian:stretch as geogetter
 ARG MAXMIND_LICENSE_KEY
 RUN apt-get update && apt-get -y install wget ca-certificates --no-install-recommends
 ADD ./common/getmmdb.sh /usr/local/bin/getmmdb.sh
-RUN /usr/local/bin/getmmdb.sh
+RUN mkdir -p /usr/share/GeoIP
+RUN /usr/local/bin/getmmdb.sh ${MAXMIND_LICENSE_KEY}
+# This is a workaround for the case where getmmdb.sh does not create any files.
+RUN touch /usr/share/GeoIP/.notempty
 
 
 # Make final image
@@ -39,6 +42,7 @@ RUN apt-get update \
 
 COPY --from=builder /usr/local/zeek-${VER} /usr/local/zeek-${VER}
 COPY --from=geogetter /usr/share/GeoIP/* /usr/share/GeoIP/
+RUN rm -f /usr/share/GeoIP/.notempty
 RUN ln -s /usr/local/zeek-${VER} /bro
 RUN ln -s /usr/local/zeek-${VER} /zeek
 ADD ./common/bro_profile.sh /etc/profile.d/zeek.sh

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: $(patsubst %.Dockerfile,build-stamp_%,$(wildcard *.Dockerfile))
 
 build-stamp_%: %.Dockerfile
-	docker build --build-arg MAXMIND_LICENSE_KEY -t broplatform/bro:$(*) -f $< . 
+	docker build --build-arg MAXMIND_LICENSE_KEY -t broplatform/zeek:$(*) -f $< . 
 	touch $@
 
 push-stamp_%: build-stamp_%

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: $(patsubst %.Dockerfile,build-stamp_%,$(wildcard *.Dockerfile))
 
 build-stamp_%: %.Dockerfile
-	docker build --build-arg MAXMIND_LICENSE_KEY -t broplatform/zeek:$(*) -f $< . 
+	docker build --build-arg MAXMIND_LICENSE_KEY -t broplatform/bro:$(*) -f $< . 
 	touch $@
 
 push-stamp_%: build-stamp_%

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: $(patsubst %.Dockerfile,build-stamp_%,$(wildcard *.Dockerfile))
 
 build-stamp_%: %.Dockerfile
-	docker build -t broplatform/bro:$(*) -f $< . 
+	docker build --build-arg MAXMIND_LICENSE_KEY -t broplatform/bro:$(*) -f $< . 
 	touch $@
 
 push-stamp_%: build-stamp_%

--- a/README.md
+++ b/README.md
@@ -1,0 +1,95 @@
+# Zeek Docker
+
+## Overview
+
+The automation in this repo provides a convenient and reproducible way for
+to standup a clean Zeek environment in a docker container.
+
+The automation compiles Zeek from source code and installs it within a
+Docker container.
+
+## Install pre-requisites
+
+If installing on Mac OSX, you will require the following.
+
+* [Docker Desktop for Mac](https://docs.docker.com/docker-for-mac/) ([install](https://docs.docker.com/docker-for-mac/install/))
+* [Homebrew](https://brew.sh/) ([install](https://brew.sh/))
+
+Important! Docker Desktop for Mac uses a VM behind the scenes to host the
+Docker runtime environment. By default it allocates 2 GB of RAM to the
+VM. This is not enough to compile Zeek! If you try with the default RAM
+allocation, you will hit a compile error that looks something like this:
+
+    c++: internal compiler error: Killed (program cc1plus)
+    Please submit a full bug report,
+    with preprocessed source if appropriate.
+    See <file:///usr/share/doc/gcc-7/README.Bugs> for instructions.
+
+This is due to the VM hitting an Out Of Memory condition. To avoid this
+you will need to allocate more RAM to the VM. Click on the Docker Icon in
+your menubar and select "Preferences". Click on the "Advanced" tab and then
+use the slider to select 8 GB of RAM (6 also works, but use 8 just in case).
+Docker Desktop will restart and then you will be ready to go.
+
+Due to recent changes in the way Maxmind supplies their
+[GeoLite2 Databases](https://blog.maxmind.com/2019/12/18/significant-changes-to-accessing-and-using-geolite2-databases/)
+a (free) license is required to download them.
+
+The steps to obtain the license are described in the blog post above:
+
+1. [Sign up for a MaxMind account](https://www.maxmind.com/en/geolite2/signup) (no purchase required)
+2. Set your password and create a [license key](https://www.maxmind.com/en/accounts/current/license-key)
+3. Setup your download mechanism by using our GeoIP Update program or
+   creating a [direct download script](https://dev.maxmind.com/geoip/geoipupdate/#Direct_Downloads)
+
+Once you have gone through all of these steps, set the MAXMIND\_LICENSE\_KEY
+variable in your environment to enable direct download of the databases:
+
+    $ export MAXMIND_LICENSE_KEY=<value of your license key>
+    
+## Check out the code
+
+Use the following command to clone this repo:
+
+    git clone git@github.com:zeek/zeek-docker.git
+
+## Build your Zeek container
+
+To build your Zeek container, type in the commands below:
+
+    $ cd zeek-docker
+    $ make build-stamp_3.0.0
+
+That's it! Now watch as the wonders of automation unfold, and your
+Zeek container is built. You should see something like this on your
+terminal console:
+
+    ...
+    Step 24/24 : CMD /bin/bash -l
+    ---> Running in c1263b7d2ea3
+    Removing intermediate container c1263b7d2ea3
+    ---> 5bc774250a9a
+    Successfully built 5bc774250a9a
+    Successfully tagged broplatform/bro:3.0.0
+    touch build-stamp_3.0.0
+    $
+
+Once the container has been built, check to make sure the container image
+is available in your local docker registry:
+
+    $ docker images  | grep -e broplatform -e REPO
+    REPOSITORY       TAG   IMAGE ID     CREATED        SIZE
+    broplatform/bro  3.0.0 5bc774250a9a 8 minutes ago  215MB
+
+Great! Let's fire it up!
+
+## Use your container
+
+Run the following command to start your container and access it via an
+interactive bash shell:
+
+    $ docker run -it -v `pwd`:/pcap broplatform/bro:3.0.0 /bin/bash
+    root@3535953ccd99:/# which zeek
+    /zeek/bin//zeek
+
+Congratulations! You are up and running with Zeek!

--- a/README.md
+++ b/README.md
@@ -32,10 +32,9 @@ use the slider to select 8 GB of RAM (6 also works, but use 8 just in case).
 Docker Desktop will restart and then you will be ready to go.
 
 Due to recent changes in the way Maxmind supplies their
-[GeoLite2 Databases](https://blog.maxmind.com/2019/12/18/significant-changes-to-accessing-and-using-geolite2-databases/)
-a (free) license is required to download them.
-
-The steps to obtain the license are described in the blog post above:
+GeoLite2 Databases a (free) license is required to download them.
+The steps to obtain the license are described in the blog post
+[here](https://blog.maxmind.com/2019/12/18/significant-changes-to-accessing-and-using-geolite2-databases/):
 
 1. [Sign up for a MaxMind account](https://www.maxmind.com/en/geolite2/signup) (no purchase required)
 2. Set your password and create a [license key](https://www.maxmind.com/en/accounts/current/license-key)

--- a/common/getmmdb.sh
+++ b/common/getmmdb.sh
@@ -1,13 +1,61 @@
 #!/bin/sh -e 
 echo "2018-09-21"
 
-mkdir -p /usr/share/GeoIP/
-wget -N http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.tar.gz
-tar xvzf GeoLite2-City.tar.gz
-rm GeoLite2-City.tar.gz
+get_geoip_db () {
+    # Fetches specified EDITION_ID db from maxmind using
+    # active LICENSE_KEY.
+    # 
+    # This gets the latest version of the db. To get db corresponding to a
+    # particular date, add the following URL paramater:
+    #
+    #   date=YYYYMMDD (e.g. 20200107)
+    #
+    # As described in [2] below, this requires an active user account
+    # and an associated LICENSE_KEY (free).
+    #
+    # References:
+    #
+    # [1] https://dev.maxmind.com/geoip/geoipupdate/#Direct_Downloads
+    # [2] https://blog.maxmind.com/2019/12/18/significant-changes-to-accessing-and-using-geolite2-databases/
 
-wget -N http://geolite.maxmind.com/download/geoip/database/GeoLite2-ASN.tar.gz
-tar xvzf GeoLite2-ASN.tar.gz
-rm GeoLite2-ASN.tar.gz
+    EDITION_ID=$1
+    SUFFIX=$2
+    LICENSE_KEY=$3
 
-mv */*.mmdb /usr/share/GeoIP
+    BASE_URL="https://download.maxmind.com/app/geoip_download"
+    wget "$BASE_URL?edition_id=$EDITION_ID&license_key=$LICENSE_KEY&suffix=$SUFFIX" \
+        -O $EDITION_ID.$SUFFIX
+}
+
+
+main () {
+    # Entry point for the script.
+    #
+    # Relies on build time environment variable: MAXMIND_LICENSE_KEY
+    # to be set.
+    mkdir -p /usr/share/GeoIP/
+
+    MD5_FILE=checksums.md5
+    rm -f $MD5_FILE
+    for DB in GeoLite2-ASN GeoLite2-City
+    do
+        get_geoip_db $DB tar.gz  $MAXMIND_LICENSE_KEY
+        get_geoip_db $DB tar.gz.md5  $MAXMIND_LICENSE_KEY
+
+        # Create MD5 sum file for cehcking
+        cat $DB.tar.gz.md5 >> $MD5_FILE
+        echo " $DB.tar.gz" >> $MD5_FILE
+    done
+
+    md5sum -c $MD5_FILE
+
+    for DB in GeoLite2-ASN GeoLite2-City
+    do
+        tar xvzf $DB.tar.gz
+        rm $DB.tar.gz
+        mv */*.mmdb /usr/share/GeoIP
+    done
+}
+
+
+main

--- a/common/getmmdb.sh
+++ b/common/getmmdb.sh
@@ -33,14 +33,15 @@ main () {
     #
     # Relies on build time environment variable: MAXMIND_LICENSE_KEY
     # to be set.
-    mkdir -p /usr/share/GeoIP/
+
+    LICENSE_KEY=$1
 
     MD5_FILE=checksums.md5
     rm -f $MD5_FILE
     for DB in GeoLite2-ASN GeoLite2-City
     do
-        get_geoip_db $DB tar.gz  $MAXMIND_LICENSE_KEY
-        get_geoip_db $DB tar.gz.md5  $MAXMIND_LICENSE_KEY
+        get_geoip_db $DB tar.gz  $LICENSE_KEY
+        get_geoip_db $DB tar.gz.md5  $LICENSE_KEY
 
         # Create MD5 sum file for cehcking
         cat $DB.tar.gz.md5 >> $MD5_FILE
@@ -57,5 +58,12 @@ main () {
     done
 }
 
+# First argument to this script is the MAXMIND_LICENSE_KEY, otherwise
+# do nothing.
+if [ -z "$1" ]
+    then
+        echo "MAXMIND_LICENSE_KEY not supplied. Skipping DB download."
+    exit 0
+fi
 
-main
+main $1


### PR DESCRIPTION
Adds a --build-arg variable MAXMIND_LICENSE_KEY which is then used
to automatically download Maxmin dbs.

Requires user to set MAXMIND_LICENSE_KEY variable in their build
environment (needs to be an active license key associated with the
users Maxmind account -- these are available for free).

This commit fixes #9.