### PR TITLE
Fix download URL

### DIFF
--- a/common/buildbro
+++ b/common/buildbro
@@ -3,7 +3,7 @@ BRO=$1
 VER=$2
 BUILD_TYPE=${3-Release}
 
-URL=https://www.bro.org/downloads/${BRO}-${VER}.tar.gz
+URL=https://old.zeek.org/downloads/${BRO}-${VER}.tar.gz
 
 echo VER is $VER
 echo URL is $URL


### PR DESCRIPTION
```console
$ make build-stamp_2.6.3
...
Step 8/23 : ENV VER 2.6.3
 ---> Running in 25563a35ec51
Removing intermediate container 25563a35ec51
 ---> 7aeee035a6cb
Step 9/23 : ADD ./common/buildbro ${WD}/common/buildbro
 ---> d14ec66d52f6
Step 10/23 : RUN ${WD}/common/buildbro bro ${VER}
 ---> Running in d171712d3d9c
VER is 2.6.3
URL is https://www.bro.org/downloads/bro-2.6.3.tar.gz
--2020-03-26 12:50:42--  https://www.bro.org/downloads/bro-2.6.3.tar.gz
Resolving www.bro.org (www.bro.org)... 192.150.187.43
Connecting to www.bro.org (www.bro.org)|192.150.187.43|:443... connected.
HTTP request sent, awaiting response... 301 Moved Permanently
Location: https://www.zeek.org/downloads/bro-2.6.3.tar.gz [following]
--2020-03-26 12:50:43--  https://www.zeek.org/downloads/bro-2.6.3.tar.gz
Resolving www.zeek.org (www.zeek.org)... 192.0.78.212, 192.0.78.150
Connecting to www.zeek.org (www.zeek.org)|192.0.78.212|:443... connected.
HTTP request sent, awaiting response... 301 Moved Permanently
Location: https://zeek.org/downloads/bro-2.6.3.tar.gz [following]
--2020-03-26 12:50:43--  https://zeek.org/downloads/bro-2.6.3.tar.gz
Resolving zeek.org (zeek.org)... 192.0.78.212, 192.0.78.150
Connecting to zeek.org (zeek.org)|192.0.78.212|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
2020-03-26 12:50:44 ERROR 404: Not Found.

The command '/bin/sh -c ${WD}/common/buildbro bro ${VER}' returned a non-zero code: 8
make: *** [Makefile:4: build-stamp_2.6.3] Error 8

```