### PR TITLE
Use old.zeek.org to download source code.

### DIFF
--- a/common/buildbro
+++ b/common/buildbro
@@ -3,7 +3,7 @@ BRO=$1
 VER=$2
 BUILD_TYPE=${3-Release}
 
-URL=https://www.bro.org/downloads/${BRO}-${VER}.tar.gz
+URL=https://old.zeek.org/downloads/${BRO}-${VER}.tar.gz
 
 echo VER is $VER
 echo URL is $URL

--- a/common/buildbro
+++ b/common/buildbro
@@ -3,7 +3,7 @@ BRO=$1
 VER=$2
 BUILD_TYPE=${3-Release}
 
-URL=https://old.zeek.org/downloads/${BRO}-${VER}.tar.gz
+URL=https://download.zeek.org/${BRO}-${VER}.tar.gz
 
 echo VER is $VER
 echo URL is $URL


### PR DESCRIPTION
Looks like bro.org cannot redirect to zeek.org/downloads which is 404 now.

Use old.zeek.org to do the direct download instead.

Fixes Issues: https://github.com/zeek/zeek-docker/issues/13