### PR TITLE
upgrade to debian bullseye

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # VERSION               0.1
 
 # Checkout and build Zeek
-FROM debian:buster as builder
+FROM debian:bullseye as builder
 MAINTAINER Justin Azoff <justin.azoff@gmail.com>
 
 ENV WD /scratch
@@ -12,7 +12,7 @@ RUN mkdir ${WD}
 WORKDIR /scratch
 
 RUN apt-get update && apt-get upgrade -y && echo 2021-03-01
-RUN apt-get -y install build-essential git bison flex gawk cmake swig libssl-dev libmaxminddb-dev libpcap-dev python3.7-dev libcurl4-openssl-dev wget libncurses5-dev ca-certificates zlib1g-dev --no-install-recommends
+RUN apt-get -y install build-essential git bison flex gawk cmake swig libssl-dev libmaxminddb-dev libpcap-dev python3.9-dev libcurl4-openssl-dev wget libncurses5-dev ca-certificates zlib1g-dev --no-install-recommends
 
 ARG ZEEK_VER=4.0.3
 ARG BUILD_TYPE=Release
@@ -25,7 +25,7 @@ ADD ./common/getmmdb.sh /usr/local/getmmdb.sh
 ADD ./common/bro_profile.sh /usr/local/bro_profile.sh
 
 # Get geoip data
-FROM debian:buster as geogetter
+FROM debian:bullseye as geogetter
 ARG MAXMIND_LICENSE_KEY
 RUN apt-get update && apt-get -y install wget ca-certificates --no-install-recommends
 
@@ -38,12 +38,12 @@ RUN /usr/local/bin/getmmdb.sh ${MAXMIND_LICENSE_KEY}
 RUN touch /usr/share/GeoIP/.notempty
 
 # Make final image
-FROM debian:buster
+FROM debian:bullseye
 ARG ZEEK_VER=4.0.3
 ENV VER ${ZEEK_VER}
 #install runtime dependencies
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends libpcap0.8 libssl1.1 libmaxminddb0 python3.7-minimal \
+    && apt-get -y install --no-install-recommends libpcap0.8 libssl1.1 libmaxminddb0 python3.9-minimal \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /usr/local/zeek-${VER} /usr/local/zeek-${VER}


### PR DESCRIPTION
bullseye was released 2021/08/14.
bullseye incorporates python3.9, so update dependency installation.