### PR TITLE
Add clarification to README that these aren't the official images

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ to standup a clean Zeek environment in a docker container.
 The automation compiles Zeek from source code and installs it within a
 Docker container.
 
+> **NOTE**
+>
+> These are not the official Zeek project Docker images. If you're
+> looking for these, please grab them from `zeek/zeek`
+> [in Docker Hub](https://hub.docker.com/r/zeek/zeek), see
+> [our documentation](https://docs.zeek.org/en/master/install.html#docker-images) for more information,
+> and go [here](https://github.com/zeek/zeek/tree/master/docker) for the Docker build setup.
+
 ## Install pre-requisites
 
 If installing on Mac OSX, you will require the following.


### PR DESCRIPTION
People are finding this repo when looking for Zeek's Docker images, so this just adds a quick clarification that this isn't those, with some pointers where to go instead.